### PR TITLE
Add Intuo GDPR data

### DIFF
--- a/data/intuo.json
+++ b/data/intuo.json
@@ -1,0 +1,43 @@
+{
+  "id": "intuo",
+  "name": "Intuo",
+  "description": "Coaching and talent enablement platform",
+  "categories": [
+    "Human Resources", 
+    "Performance Management"
+  ],
+  "iconUrl": "https://s3.eu-central-1.amazonaws.com/intuo-marketing-assets/intuo_icon_app_200x200_blue_grad.png",
+  "website": "https://www.intuo.io",
+  "countryHQ": "BE",
+  "gdprReadyStatus": "ready",
+  "privacyUrl": "https://www.intuo.io/terms-conditions",
+  "dsarFormUrl": "",
+  "dpaUrl": "",
+  "dataCenters": [
+    "EU"
+  ],
+  "hostingPartners": [
+    "AWS"
+  ],
+  "contacts": [
+    {
+      "type": "DPO",
+      "name": "Fé Zenner",
+      "email": "fe@intuo.io",
+      "region": "EU"
+    }, 
+    {
+      "type": "DPO",
+      "name": "Philip De Smedt",
+      "email": "philip@intuo.io",
+      "region": "EU"
+    }
+  ],
+  "certifications": [
+    "ISO27k"
+  ],
+  "articles": [{
+    "date": "01/03/2018",
+    "url": "https://www.intuo.io/security"
+  }]
+}

--- a/data/intuo.json
+++ b/data/intuo.json
@@ -34,7 +34,7 @@
     }
   ],
   "certifications": [
-    "ISO27k"
+    "ISO 27001"
   ],
   "articles": [{
     "date": "01/03/2018",


### PR DESCRIPTION
A few comments:

- We do not publicly expose our DPA (for now)
- We do not have a public Data Subject Access Rights Form. Our users have an internal GDPR form inside of the product for most things (Right to be forgotten etc). Having said that, a public form on gdprform.io would be nice. Couldn't see how to sign up tho :)
- Our Privacy Terms are in review and not publicly either yet. Will update it when done. 