### PR TITLE
Fix bad "countryHQ" in EmailOctopus.

### DIFF
--- a/data/emailoctopus.json
+++ b/data/emailoctopus.json
@@ -7,7 +7,7 @@
   ],
   "iconUrl": "https://emailoctopus.com/bundles/emailoctopuswebsite/images/logo.svg",
   "website": "https://emailoctopus.com",
-  "countryHQ": "UK",
+  "countryHQ": "GB",
   "gdprReadyStatus": "ready",
   "privacyUrl": "https://emailoctopus.com/legal/privacy",
   "dsarUrl": "https://support.emailoctopus.com/hc/en-us/requests/new",


### PR DESCRIPTION
Sorry - slight error on our countryHQ value.