### PR TITLE
Update of the contact info

### DIFF
--- a/data/productboard.json
+++ b/data/productboard.json
@@ -37,7 +37,7 @@
     ],
     "contacts": [ 
         {
-          "type": "DPO",
+          "type": "Other",
           "name": "Daniel Hejl",
           "email": "gdpr@productboard.com",
           "region": "EU"


### PR DESCRIPTION
Correcting DPO -> Other. Daniel Hejl is our representative for data protection in the EU, per https://gdpr-info.eu/art-27-gdpr/ (not a DPO - article 37)