### PR TITLE
Add EU sending region to mailgun.json

### DIFF
--- a/data/mailgun.json
+++ b/data/mailgun.json
@@ -15,7 +15,10 @@
   "dsarUrl": "",
   "dpaUrl": "https://app.hellosign.com/s/2dc49398",
   "subprocessorsUrl": "",
-  "dataCenters": [],
+  "dataCenters": [
+    "US",
+    "EU"
+  ],
   "hostingPartners": [
     "AWS",
     "Rackspace",


### PR DESCRIPTION
Mailgun has just announced a new region for the EU: [https://www.mailgun.com/blog/we-have-a-new-region-in-europe-yall](https://www.mailgun.com/blog/we-have-a-new-region-in-europe-yall)