### PR TITLE
Remove personal data

### DIFF
--- a/data/lever-co.json
+++ b/data/lever-co.json
@@ -2,7 +2,7 @@
     "id": "lever-co",
     "name": "Lever",
     "dpaUrl": "",
-    "dsarUrl": "https://jobs.lever.co/lever-ent-demo/m/17c0e4e3-5469-48e2-8c22-d682b66e9deb?tab=data",
+    "dsarUrl": "",
     "iconUrl": "https://res.cloudinary.com/gdprtracker-io/image/upload/v1529505546/leverco.png",
     "twitter": "lever",
     "website": "https://www.lever.co/",


### PR DESCRIPTION
The DSAR link appears to be to one specific individual's completed SAR, and I wasn't able to find the correct link. So I just removed it.