### PR TITLE
Added EU-U.S. Privacy Shield Certification to MG

### DIFF
--- a/data/mailgun.json
+++ b/data/mailgun.json
@@ -25,7 +25,9 @@
     "SoftLayer"
   ],
   "contacts": [],
-  "certifications": [],
+  "certifications": [
+    "EU-U.S. Privacy Shield"
+  ],
   "dataBreaches": [
     {
       "date": "January 3, 2018",


### PR DESCRIPTION
Mailgun has achieved EU-U.S. Privacy Shield certification in 2017.

https://www.privacyshield.gov/participant?id=a2zt0000000PCbmAAG&status=Active